### PR TITLE
Add extendr to R type mapping 

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -17,6 +17,7 @@ website:
       - hello-world.qmd
       - project-structure.qmd
       - conversion.qmd
+      - data-types.qmd
     style: "docked"
     search: true
   navbar:

--- a/data-types.qmd
+++ b/data-types.qmd
@@ -1,0 +1,47 @@
+---
+title: R to Rust type mapping
+---
+
+extendr is allows us to create a bridge between R and Rust. When writing a function in Rust that is intended to be called from R, it is important that the input types be R types. There are many types of objects in R (almost) all of which are available in extendr via a wrapper struct. 
+
+The below lists the extendr structs that wrap R object types. These types can be used as function arguments or return values. 
+
+## Scalar types
+
+| R type | extendr type | Rust type | 
+| ------| -----------| ----------|
+| `integer(1)` | `Rint` |  `i32` |
+| `double(1)` | `Rfloat` |  `f64` | 
+| `logical(1)` | `Rbool` | `bool` |
+| `complex(1)` | `Rcplx` | `Complex<f64>` | 
+| `character(1)` |  `Rstr` | `String` | 
+
+## Vector types
+
+| R type        | extendr type | extendr scalar type | C API Type |
+|-------------|------------|-------------------|----------|
+| `integer()`   | `Integers`   |  `Rint`  | `INTSXP`  | 
+| `double()`    | `Doubles`    | `Rfloat` | `REALSXP` |
+| `logical()`   | `Logicals`   | `Rbool`  | `LGLSXP`  |
+| `complex()`   | `Complexes`  | `Rcplx`  | `CPLXSXP` |
+| `character()` | `Strings`    |  `Rstr`  | `STRSXP`  |
+| `raw()`       | `Raw`        |  `&[u8]` | `RAWSXP`  |
+| `list()`      | `List`       | `Robj`   | `VECSXP`  |
+
+
+## Other types 
+
+
+- [`Environment`](https://extendr.github.io/extendr/extendr_api/wrapper/environment/struct.Environment.html) (`ENVSXP`)
+- [`Expressions`](https://extendr.github.io/extendr/extendr_api/wrapper/expr/struct.Expressions.html) (`EXPRSXP`)
+- [`ExternalPtr`](https://extendr.github.io/extendr/extendr_api/wrapper/externalptr/struct.ExternalPtr.html)
+- [`Function`](https://extendr.github.io/extendr/extendr_api/wrapper/function/struct.Function.html) (`CLOSSXP`)
+- [`Language`](https://extendr.github.io/extendr/extendr_api/wrapper/lang/struct.Language.html)
+- [`RArray`](https://extendr.github.io/extendr/extendr_api/wrapper/matrix/struct.RArray.html)
+- [`Pairlist`](https://extendr.github.io/extendr/extendr_api/wrapper/pairlist/struct.Pairlist.html)
+- [`Promise`](https://extendr.github.io/extendr/extendr_api/wrapper/promise/struct.Promise.html) (`PROMSXP`)
+- [`S4`](https://extendr.github.io/extendr/extendr_api/wrapper/s4/struct.S4.html)
+
+## Using Rust library types vs R-native types
+
+## Returning Rust values to R

--- a/data-types.qmd
+++ b/data-types.qmd
@@ -38,7 +38,7 @@ The below lists the extendr structs that wrap R object types. These types can be
 - [`Function`](https://extendr.github.io/extendr/extendr_api/wrapper/function/struct.Function.html) (`CLOSSXP`)
 - [`Language`](https://extendr.github.io/extendr/extendr_api/wrapper/lang/struct.Language.html)
 - [`RArray`](https://extendr.github.io/extendr/extendr_api/wrapper/matrix/struct.RArray.html)
-- [`Pairlist`](https://extendr.github.io/extendr/extendr_api/wrapper/pairlist/struct.Pairlist.html)
+- [`Pairlist`](https://extendr.github.io/extendr/extendr_api/wrapper/pairlist/struct.Pairlist.html) (`LISTSXP`)
 - [`Promise`](https://extendr.github.io/extendr/extendr_api/wrapper/promise/struct.Promise.html) (`PROMSXP`)
 - [`S4`](https://extendr.github.io/extendr/extendr_api/wrapper/s4/struct.S4.html)
 

--- a/data-types.qmd
+++ b/data-types.qmd
@@ -34,13 +34,13 @@ The below lists the extendr structs that wrap R object types. These types can be
 
 - [`Environment`](https://extendr.github.io/extendr/extendr_api/wrapper/environment/struct.Environment.html) (`ENVSXP`)
 - [`Expressions`](https://extendr.github.io/extendr/extendr_api/wrapper/expr/struct.Expressions.html) (`EXPRSXP`)
-- [`ExternalPtr`](https://extendr.github.io/extendr/extendr_api/wrapper/externalptr/struct.ExternalPtr.html)
+- [`ExternalPtr`](https://extendr.github.io/extendr/extendr_api/wrapper/externalptr/struct.ExternalPtr.html) (`EXTPTRSXP`)
 - [`Function`](https://extendr.github.io/extendr/extendr_api/wrapper/function/struct.Function.html) (`CLOSSXP`)
-- [`Language`](https://extendr.github.io/extendr/extendr_api/wrapper/lang/struct.Language.html)
+- [`Language`](https://extendr.github.io/extendr/extendr_api/wrapper/lang/struct.Language.html) (`LANGSXP`)
 - [`RArray`](https://extendr.github.io/extendr/extendr_api/wrapper/matrix/struct.RArray.html)
 - [`Pairlist`](https://extendr.github.io/extendr/extendr_api/wrapper/pairlist/struct.Pairlist.html) (`LISTSXP`)
 - [`Promise`](https://extendr.github.io/extendr/extendr_api/wrapper/promise/struct.Promise.html) (`PROMSXP`)
-- [`S4`](https://extendr.github.io/extendr/extendr_api/wrapper/s4/struct.S4.html)
+- [`S4`](https://extendr.github.io/extendr/extendr_api/wrapper/s4/struct.S4.html) (`S4SXP`)
 
 ## Using Rust library types vs R-native types
 


### PR DESCRIPTION
This is a preliminary draft of a type mapping doc drawing on the [PyO3 docs](https://pyo3.rs/v0.21.0/conversions/tables). 

The two types that I am unsure if I documented correctly are `Rstr` (which is rather complicated) as well as the `Raw` where i wrote that the inner type is `&[u8]`.


For `Rstr` I wrote that the inner Rust type is `String` for simplicity sake—as this is what most people will convert into an `Rstr`. 
